### PR TITLE
Add codespell per Kay

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,2 +1,3 @@
 [codespell]
-
+skip = *index.html,*.lock,*.css
+ignore-words-list = Covert

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,2 @@
 [codespell]
-skip = '*index.html,*.lock,*.css'
-ignore-words-list = 'Covert'
+

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = '*index.html, *.lock, *.css'
-ignore-words-list = 'covert'
+skip = '*index.html,*.lock,*.css'
+ignore-words-list = 'Covert'

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = '*index.html, *.lock, *.css'
+ignore-words-list = 'covert'

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -1,0 +1,22 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2


### PR DESCRIPTION
Error: ./interactive/hed_full.json:1263: automatized ==> automated
Error: ./schema_browser/README.md:1: maintainance ==> maintenance
Error: ./schema_browser/README.md:21: specfied ==> specified
Error: ./cta/tree.json:205: Acces ==> Access
Error: ./hed-docs/quick-guide-old.md:61: faciliate ==> facilitate
Error: ./hed-docs/quick-guide-old.md:69: aggregrate ==> aggregate
Error: ./hed-docs/quick-guide-old.md:71: partcipant ==> participant
Error: ./hed-docs/quick-guide-old.md:102: seperated ==> separated

Add words or file patterns to .codespellrc if any of the above should be supressed.  Only set to run on develop branch(modify in the workflow yaml)